### PR TITLE
Revert "Switch to C++20"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -707,9 +707,9 @@ AX_CHECK_COMPILE_FLAG([-fstack-protector-strong],
   [AC_SUBST(STACK_PROTECTOR, "-fstack-protector-strong")],
   [AC_SUBST(STACK_PROTECTOR, "-fstack-protector")])
 
-# Ensure that CXX supports C++20 (with "strict" conformance), and set
+# Ensure that CXX supports C++11 (with "strict" conformance), and set
 # "--std=" flag and CXXFLAGS environment variable as appropriate.
-AX_CXX_COMPILE_STDCXX([20], [noext], [mandatory])
+AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
 
 # Blacklist known incompatible C++ standard libraries to reduce chance
 # of users accidentally using them.


### PR DESCRIPTION
This reverts commit b81b4b24860861a00fdd6fcfc1807d6fa1fd0a7b.

As it turned out, the autotools that we use do not allow for C++20 anyway (see https://github.com/alisw/alidist/pull/5793#discussion_r2007429646 ). This commit revert is to allow for a next patch release.